### PR TITLE
polish - mode-line: same height active / inactive

### DIFF
--- a/spacemacs/extensions/spacemacs-theme/spacemacs-light-theme.el
+++ b/spacemacs/extensions/spacemacs-theme/spacemacs-light-theme.el
@@ -102,11 +102,12 @@
    `(page-break-lines ((,class (:foreground ,active2))))
    `(mode-line
      ((,class (:foreground ,base
-                           :background ,active1))))
+                           :background ,active1
+                           :box (:color "#B3B9BE" :line-width 1)))))
    `(mode-line-inactive
      ((,class (:foreground ,base
                            :background ,bg1
-                           :box (:color ,inactive :line-width 1)))))
+                           :box (:color "#B3B9BE" :line-width 1)))))
    `(mode-line-buffer-id ((,class (:bold t :foreground ,func))))
 
 ;;;;; powerline


### PR DESCRIPTION
When you have a split the - active - mode-line "height looks shorter because there's no border.
I Understand that it looks nicer without border and the inactive needs contrast, but, I added neutral color so it looks as nice as possible.
